### PR TITLE
fix: use execFileSync to (un)install packages

### DIFF
--- a/src/files/PackageFile.ts
+++ b/src/files/PackageFile.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
 */
 
+import { execFileSync } from 'fs';
 import { packageJson, install, uninstall } from 'mrm-core'
 import { BaseFile } from '../base/BaseFile'
 
@@ -175,7 +176,7 @@ export class PackageFile extends BaseFile {
       options.yarn = this._useYarn
     }
 
-    install(list, options)
+    install(list, options, execFileSync)
   }
 
   /**
@@ -190,7 +191,7 @@ export class PackageFile extends BaseFile {
       options.yarn = this._useYarn
     }
 
-    uninstall(list, options)
+    uninstall(list, options, execFileSync)
   }
 
   /**


### PR DESCRIPTION
By default, mrm-core returns the result of `child_process.spawnSync`.
In case of errors, `spawnSync` doesn't throw, so the process continues even if nothing was installed.
`execFileSync` takes the same parameters as `spawnSync` but throws if the command returned an error.

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/null/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
