### PR TITLE
feat(env): fill the example file too

### DIFF
--- a/src/Files/Special/Env.ts
+++ b/src/Files/Special/Env.ts
@@ -31,8 +31,8 @@ export class EnvFile {
       return this
     }
 
-    this.envContents.add(`${key}=${value}`)
-    this.exampleEnvContents.add(`${key}=`)
+    this.envContents.add(newText)
+    this.exampleEnvContents.add(newText)
     return this
   }
 

--- a/test/env-file.spec.ts
+++ b/test/env-file.spec.ts
@@ -31,7 +31,7 @@ test.group('EnvFile', (group) => {
     const contents = await fs.get('.env')
     const exampleFileContents = await fs.get('.env.example')
     assert.deepEqual(contents.trim(), 'APP_KEY=foo-bar')
-    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=')
+    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=foo-bar')
   })
 
   test('write subsitution variables inside .env file', async (assert) => {
@@ -44,12 +44,15 @@ test.group('EnvFile', (group) => {
     const exampleFileContents = await fs.get('.env.example')
 
     assert.deepEqual(contents.trim(), ['URL=$HOST:$PORT', 'PASSWORD=pa\\$\\$word'].join('\n'))
-    assert.deepEqual(exampleFileContents.trim(), ['URL=', 'PASSWORD='].join('\n'))
+    assert.deepEqual(
+      exampleFileContents.trim(),
+      ['URL=$HOST:$PORT', 'PASSWORD=pa\\$\\$word'].join('\n')
+    )
   })
 
   test('update existing key value', async (assert) => {
     await fs.add('.env', 'APP_KEY=foo-bar')
-    await fs.add('.env.example', 'APP_KEY=')
+    await fs.add('.env.example', 'APP_KEY=foo-bar')
 
     const envFile = new EnvFile(fs.basePath)
     envFile.set('APP_KEY', 'bar')
@@ -59,12 +62,12 @@ test.group('EnvFile', (group) => {
     const exampleFileContents = await fs.get('.env.example')
 
     assert.deepEqual(contents.trim(), 'APP_KEY=bar')
-    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=')
+    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=foo-bar')
   })
 
   test('remove existing key', async (assert) => {
     await fs.add('.env', 'APP_KEY=foo-bar')
-    await fs.add('.env.example', 'APP_KEY=')
+    await fs.add('.env.example', 'APP_KEY=foo-bar')
 
     const envFile = new EnvFile(fs.basePath)
     envFile.unset('APP_KEY')
@@ -79,7 +82,7 @@ test.group('EnvFile', (group) => {
 
   test('remove line to rollback', async (assert) => {
     await fs.add('.env', 'APP_KEY=foo-bar')
-    await fs.add('.env.example', 'APP_KEY=')
+    await fs.add('.env.example', 'APP_KEY=foo-bar')
 
     const envFile = new EnvFile(fs.basePath)
     envFile.set('APP_KEY', 'foo-bar')
@@ -94,7 +97,7 @@ test.group('EnvFile', (group) => {
 
   test('do not touch destructive commits on rollbacks', async (assert) => {
     await fs.add('.env', 'APP_KEY=foo')
-    await fs.add('.env.example', 'APP_KEY=')
+    await fs.add('.env.example', 'APP_KEY=foo')
 
     const envFile = new EnvFile(fs.basePath)
     envFile.unset('APP_KEY')
@@ -104,12 +107,12 @@ test.group('EnvFile', (group) => {
     const exampleFileContents = await fs.get('.env.example')
 
     assert.deepEqual(contents.trim(), 'APP_KEY=foo')
-    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=')
+    assert.deepEqual(exampleFileContents.trim(), 'APP_KEY=foo')
   })
 
   test('get file contents', async (assert) => {
     await fs.add('.env', 'APP_KEY=foo')
-    await fs.add('.env.example', 'APP_KEY=')
+    await fs.add('.env.example', 'APP_KEY=foo')
 
     const envFile = new EnvFile(fs.basePath)
     assert.deepEqual(envFile.get(), { APP_KEY: 'foo' })


### PR DESCRIPTION
Hey! 👋 

## Proposed changes

This PR change how we populate the `.env.example` file.

Before, we weren't putting the default value inside the example file.
I believe the DX would be better if the default value would also be added to this file, since it is the one committed and copied to start the project in a new machine.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

